### PR TITLE
Add missing ontology definition and avoid redefinition from other ontologies.

### DIFF
--- a/context/discovery-context.jsonld
+++ b/context/discovery-context.jsonld
@@ -30,21 +30,20 @@
       "@id": "discovery:hasRegistrationInformation",
       "@type": "@id",
       "@context": {
-        "schema": "http://schema.org/",
         "RegistrationInformation": {
           "@id": "discovery:RegistrationInformation",
           "@type": "@id"
         },
         "created": {
-          "@id": "schema:dateCreated",
+          "@id": "discovery:dateCreated",
           "@type": "xsd:dateTime"
         },
         "modified": {
-          "@id": "schema:dateModified",
+          "@id": "discovery:dateModified",
           "@type": "xsd:dateTime"
         },
         "expires": {
-          "@id": "schema:expires",
+          "@id": "discovery:expires",
           "@type": "xsd:dateTime"
         },
         "retrieved": {

--- a/context/discovery-ontology.ttl
+++ b/context/discovery-ontology.ttl
@@ -28,6 +28,18 @@ discovery:hasRegistrationInformation rdf:type owl:ObjectProperty ;
 	rdfs:range discovery:RegitrationInformation ;
 	rdfs:label "registration" .
 
+### discovery:nextThingCollection
+discovery:nextThingCollection rdf:type owl:ObjectProperty;
+    rdfs:domain discovery:ThingCollection;
+    rdfs:range discovery:ThingCollection;
+    rdfs:label "next ThingCollection" .
+
+
+### discovery:members
+discovery:members rdf:type owl:ObjectProperty;
+    rdfs:domain discovery:ThingCollection;
+    rdfs:range discovery:Thing;
+    rdfs:label "ThingCollection members" .
 #################################################################
 
 # Data Properties
@@ -64,6 +76,11 @@ discovery:retrieved rdf:type owl:DatatypeProperty ;
 	rdfs:range xsd:dateTime ;
 	rdfs:label "retrieved"@en .
 
+### discovery:total
+discovery:total rdf:type owl:DatatypeProperty ;
+	rdfs:domain discovery:ThingCollection;
+	rdfs:range xsd:integer;
+	rdfs:label "total"@en .
 #################################################################
 
 # Classes
@@ -86,6 +103,11 @@ discovery:ThingLink rdf:type owl:Class ;
 ### discovery:ThingDirectory
 discovery:ThingDirectory rdf:type owl:Class ;
 	rdfs:label "ThingDirectory" ;
+	rdfs:subClassOf td:Thing .
+
+### discovery:ThingCollection
+discovery:ThingCollection rdf:type owl:Class ;
+	rdfs:label "ThingCollection" ;
 	rdfs:subClassOf td:Thing .
 
 #################################################################

--- a/context/discovery-ontology.ttl
+++ b/context/discovery-ontology.ttl
@@ -25,7 +25,7 @@
 ### discovery:hasRegistrationInformation
 discovery:hasRegistrationInformation rdf:type owl:ObjectProperty ;
 	rdfs:domain td:Thing ;
-	rdfs:range discovery:RegitrationInformation ;
+	rdfs:range discovery:RegistrationInformation ;
 	rdfs:label "registration" .
 
 ### discovery:nextThingCollection
@@ -35,10 +35,10 @@ discovery:nextThingCollection rdf:type owl:ObjectProperty;
     rdfs:label "next ThingCollection" .
 
 
-### discovery:members
-discovery:members rdf:type owl:ObjectProperty;
+### discovery:hasCollectionMember
+discovery:hasCollectionMember rdf:type owl:ObjectProperty;
     rdfs:domain discovery:ThingCollection;
-    rdfs:range discovery:Thing;
+    rdfs:range td:Thing;
     rdfs:label "ThingCollection members" .
 #################################################################
 
@@ -49,50 +49,50 @@ discovery:members rdf:type owl:ObjectProperty;
 ### discovery:dateCreated
 discovery:dateCreated rdf:type owl:DatatypeProperty ;
     rdfs:subPropertyOf schema:dateCreated;
-	rdfs:domain discovery:RegitrationInformation ;
+	rdfs:domain discovery:RegistrationInformation ;
 	rdfs:range xsd:dateTime ;
 	rdfs:label "created"@en .
 
 ### discovery:dateModified
 discovery:dateModified rdf:type owl:DatatypeProperty ;
     rdfs:subPropertyOf schema:dateModified;
-	rdfs:domain discovery:RegitrationInformation ;
+	rdfs:domain discovery:RegistrationInformation ;
 	rdfs:range xsd:dateTime ;
 	rdfs:label "modified"@en .
 
 ### discovery:expires
 discovery:expires rdf:type owl:DatatypeProperty ;
     rdfs:subPropertyOf schema:expires
-	rdfs:domain discovery:RegitrationInformation ;
+	rdfs:domain discovery:RegistrationInformation ;
 	rdfs:range xsd:dateTime ;
 	rdfs:label "expires"@en .
 
 ### discovery:ttl
 discovery:ttl rdf:type owl:DatatypeProperty ;
-	rdfs:domain discovery:RegitrationInformation ;
+	rdfs:domain discovery:RegistrationInformation ;
 	rdfs:range xsd:unsignedInt ;
 	rdfs:label "ttl"@en .
 
 ### discovery:retrieve
 discovery:retrieved rdf:type owl:DatatypeProperty ;
-	rdfs:domain discovery:RegitrationInformation ;
+	rdfs:domain discovery:RegistrationInformation ;
 	rdfs:range xsd:dateTime ;
 	rdfs:label "retrieved"@en .
 
-### discovery:total
-discovery:total rdf:type owl:DatatypeProperty ;
+### discovery:contains
+discovery:contains rdf:type owl:DatatypeProperty ;
 	rdfs:domain discovery:ThingCollection;
 	rdfs:range xsd:integer;
-	rdfs:label "total"@en .
+	rdfs:label "total number of things contained in the collection"@en .
 #################################################################
 
 # Classes
 
 #################################################################
 
-### discovery:RegitrationInformation
-discovery:RegitrationInformation rdf:type owl:Class ;
-	rdfs:label "RegitrationInformation" .
+### discovery:RegistrationInformation
+discovery:RegistrationInformation rdf:type owl:Class ;
+	rdfs:label "RegistrationInformation" .
 
 ### discovery:ThingLink
 discovery:ThingLink rdf:type owl:Class ;
@@ -106,8 +106,7 @@ discovery:ThingDirectory rdf:type owl:Class ;
 
 ### discovery:ThingCollection
 discovery:ThingCollection rdf:type owl:Class ;
-	rdfs:label "ThingCollection" ;
-	rdfs:subClassOf td:Thing .
+	rdfs:label "ThingCollection".
 
 #################################################################
 # Instances

--- a/context/discovery-ontology.ttl
+++ b/context/discovery-ontology.ttl
@@ -46,20 +46,23 @@ discovery:members rdf:type owl:ObjectProperty;
 
 #################################################################
 
-### schema:dateCreated
-schema:dateCreated rdf:type owl:DatatypeProperty ;
+### discovery:dateCreated
+discovery:dateCreated rdf:type owl:DatatypeProperty ;
+    rdfs:subPropertyOf schema:dateCreated;
 	rdfs:domain discovery:RegitrationInformation ;
 	rdfs:range xsd:dateTime ;
 	rdfs:label "created"@en .
 
-### schema:dateModified
-schema:dateModified rdf:type owl:DatatypeProperty ;
+### discovery:dateModified
+discovery:dateModified rdf:type owl:DatatypeProperty ;
+    rdfs:subPropertyOf schema:dateModified;
 	rdfs:domain discovery:RegitrationInformation ;
 	rdfs:range xsd:dateTime ;
 	rdfs:label "modified"@en .
 
-### schema:expires
-schema:expires rdf:type owl:DatatypeProperty ;
+### discovery:expires
+discovery:expires rdf:type owl:DatatypeProperty ;
+    rdfs:subPropertyOf schema:expires
 	rdfs:domain discovery:RegitrationInformation ;
 	rdfs:range xsd:dateTime ;
 	rdfs:label "expires"@en .

--- a/context/discovery-ontology.ttl
+++ b/context/discovery-ontology.ttl
@@ -87,10 +87,6 @@ discovery:total rdf:type owl:DatatypeProperty ;
 
 #################################################################
 
-### td:Thing
-td:Thing rdf:type owl:Class ;
-	rdfs:label "Thing" .
-
 ### discovery:RegitrationInformation
 discovery:RegitrationInformation rdf:type owl:Class ;
 	rdfs:label "RegitrationInformation" .


### PR DESCRIPTION
This PR adds some missing definition into the ontology, but used in the context.
It removes the redefinition of td:Thing.
It defines its proper object properties, which inherit from schema ones and remove the schema properties definition.